### PR TITLE
Corrected tests in levels 4, 28, 41 (sorting errors)

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,13 +51,7 @@ var generators = {
     '4': function (inbox) {
         // Output each pair with the items sorted in reverse order
         return splitGroups(inbox, 2).reduce(function (outbox, pair) {
-            return outbox.concat(pair.sort(function (a, b) {
-                return a === b
-                    ? 0
-                    : a < b
-                        ? 1
-                        : -1;
-            }));
+            return outbox.concat([ pair[1], pair[0] ]);
         }, []);
     },
     /*** Coffee Time ***/
@@ -233,7 +227,9 @@ var generators = {
     '28': function (inbox) {
         // For each triple, sort then output
         return splitGroups(inbox, 3).reduce(function (outbox, triplet) {
-            return outbox.concat(triplet.sort());
+            return outbox.concat(Number.isInteger(triplet[0]) ?
+                            triplet.sort(function(a,b){ return a - b; }) :
+                            triplet.sort() );
         }, []);
     },
     /*** Storage Floor ***/
@@ -349,7 +345,9 @@ var generators = {
         // Split strings, sort items in each string, then output all strings
         return splitStrings(inbox)
             .map(function (string) {
-                return string.sort();
+                return ( Number.isInteger(string[0]) ?
+                            string.sort(function(a,b){ return a - b; }) :
+                            string.sort() );
             })
             .reduce(function (output, string) {
                 return output.concat(string);


### PR DESCRIPTION
Level 4 should swap entries, not sort them. The other levels need to handle sorts differently for ints and strings because Javascript derp.
Fixes #1 
Fixes atesgoral/hrm-solutions#262